### PR TITLE
Preserve timestamps when copying files

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ for FILENAME in $(cat ${BUILD_DIR}/.buildcache | sed '/^$/d'); do
   fi
 
   # copy files from cache
-  cp -r ${SRC} ${DEST}
+  cp -p -r ${SRC} ${DEST}
 
   echo " ✓"
 done


### PR DESCRIPTION
This is important so the assets cleanup phases correctly detect old files.